### PR TITLE
Ignore .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+.env*
+


### PR DESCRIPTION
This change adds `*.env` to the `.gitignore` to help prevent folks accidentally committing their secrets.