### PR TITLE
Add ssl call to make connection

### DIFF
--- a/pages/api/database-connection.js
+++ b/pages/api/database-connection.js
@@ -7,6 +7,7 @@ export default async (req, res) => {
     port: process.env.MYSQL_PORT,
     user: process.env.MYSQL_USER,
     password: process.env.MYSQL_PASSWORD,
+    ssl: {}
   });
 
   const [rows] = await connection.query("SELECT 1 as value");


### PR DESCRIPTION
Added an `ssl: {}` option call to the connection setup that fixed:

```
Error: unknown error: Code: UNAVAILABLE
server does not allow insecure connections, client must use SSL/TLS
```
